### PR TITLE
fix: setting hash mode

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -68,7 +68,7 @@ const routes = [
 ];
 
 const router = new VueRouter({
-  mode: 'history',
+  mode: 'hash',
   base: process.env.BASE_URL,
   routes,
   scrollBehavior() {


### PR DESCRIPTION
Setting router mode to hash. When F5 pressed, a 404 page was being showed.